### PR TITLE
feat: generate page with vite ssr API

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -1,20 +1,29 @@
 const fs = require('fs');
 const path = require('path');
+const { createServer } = require('vite');
 
 const INDEX_HTML_PATH = path.resolve(__dirname, 'dist/static/index.html');
-const { render } = require('./dist/server/entry-server.js');
+const ENTRY_SERVER_PATH = `${true ? './dist/server' : '/src'}/entry-server.js`;
 
 
 (async () => {
+  const vite = await createServer({
+    server: { middlewareMode: 'ssr' }
+  })
+  const url = '/';
   // 1. Read
-  const template = fs.readFileSync(INDEX_HTML_PATH, 'utf-8');
+  let template = fs.readFileSync(INDEX_HTML_PATH, 'utf-8');
 
   // 2. Render
-  const appHtml = await render('/');
-  const html = template.replace('<!--server-outlet-->', appHtml);
-
+  template = await vite.transformIndexHtml(url, template)
+  const { render } = require(ENTRY_SERVER_PATH);
+  const appHtml = await render(url)
+  
+  // 5. Inject the app-rendered HTML into the template.
+  const html = template.replace(`<!--server-outlet-->`, appHtml)
   // 3. Write
   fs.writeFileSync(INDEX_HTML_PATH, html);
   console.log('Generated index.html');
   console.log('`npx serve dist/static` to run static server');
+  vite.close();
 })();


### PR DESCRIPTION
Instead of generating the way it is done in [demo prerender script mentioned in vite docs](https://github.com/vitejs/vite/blob/main/packages/playground/ssr-vue/prerender.js). I am now generating the page with the same Vite SSR API that is used in generating pages.

This helps in keeping dev-server and generate code close to each other. Also helping in some path resolutions in index.html because of client-side js code resolution